### PR TITLE
adds privacy provider.

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for tool_ribbons.
+ *
+ * @package    tool_ribbons
+ * @copyright  2024 The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_ribbons\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy Subsystem for tool_ribbons implementing null_provider.
+ *
+ * @package    tool_ribbons
+ * @copyright  2024 The Regents of the University of California
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements null_provider {
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/tool_ribbons.php
+++ b/lang/en/tool_ribbons.php
@@ -65,3 +65,6 @@ $string['right-bottom'] = 'right-bottom';
 // Types.
 $string['static'] = 'static';
 $string['script'] = 'script';
+
+// Privacy.
+$string['privacy:metadata'] = 'The Environment ribbons plugin does not store any personal data.';


### PR DESCRIPTION
this plugin doesn't store any user information, so implementing the null provider is sufficient enough.

fixes https://github.com/cwarwicker/moodle-tool_ribbons/issues/8