### PR TITLE
Do not process ribbons during installation

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -28,6 +28,8 @@ use core\hook\output\before_standard_top_of_body_html_generation;
 
 defined('MOODLE_INTERNAL') || die;
 
+require_once(__DIR__ . '/../lib.php');
+
 /**
  * Hook callbacks for tool_ribbons.
  * @package    tool_ribbons

--- a/lib.php
+++ b/lib.php
@@ -39,6 +39,14 @@ defined('MOODLE_INTERNAL') || die();
  * @return string|void The legacy implementation returns a string, the hook implementation returns nothing.
  */
 function tool_ribbons_before_standard_top_of_body_html_callback(&$hook = null) {
+    // Ignore during initial Moodle installation and initial plugin installation.
+    if (during_initial_install() || !get_config('tool_ribbon', 'version')) {
+        if ($hook) {
+            return;
+        }
+        return '';
+    }
+
     $output = '';
 
     // Load the ribbons.
@@ -73,6 +81,14 @@ function tool_ribbons_before_standard_top_of_body_html_callback(&$hook = null) {
  * @return string|void The legacy implementation returns a string, the hook implementation returns nothing.
  */
 function tool_ribbons_before_standard_html_head_callback(&$hook = null) {
+    // Ignore during initial Moodle installation and initial plugin installation.
+    if (during_initial_install() || !get_config('tool_ribbon', 'version')) {
+        if ($hook) {
+            return;
+        }
+        return '';
+    }
+
     $output = '<style type="text/css">';
 
     // Load the ribbons.


### PR DESCRIPTION
follow-up to https://github.com/cwarwicker/moodle-tool_ribbons/pull/11

as we discovered, the new hooks fire during the installation process and break the install. this PR aims to fix this by exiting early, before any reads against the (non-existent) ribbons database tables are performed.

found and fixed a missing include in the hooks definitions file, which also only manifested itself during system installs. 

anyway, this should set things right again for fresh installs. 